### PR TITLE
Use ASCII_TERMINFO so that it does not interfere with z/OS TERMINFO ebcdic database

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,7 +1,7 @@
 export ZOPEN_GIT_URL="https://github.com/mirror/ncurses.git"
 export ZOPEN_GIT_DEPS="git curl make gawk"
 export ZOPEN_TARBALL_URL="https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.3.tar.gz"
-export ZOPEN_TARBALL_DEPS="curl make gzip tar gawk"
+export ZOPEN_TARBALL_DEPS="curl make gzip tar gawk sed coreutils"
 export ZOPEN_TYPE="TARBALL"
 export ZOPEN_MAKE_MINIMAL="yes"
 export ZOPEN_CHECK="${ZOPEN_ROOT}/test.sh"
@@ -24,7 +24,7 @@ zopen_append_to_env()
 {
 cat <<ZZ
 export TERM=xterm
-export TERMINFO="\$PWD/share/terminfo/"
+export ASCII_TERMINFO="\$PWD/share/terminfo/"
 if [ ! -z "\$ZOPEN_IN_ZOPEN_BUILD" ]; then
   export ZOPEN_EXTRA_CFLAGS="\${ZOPEN_EXTRA_CFLAGS} -I\$PWD/include"
   export ZOPEN_EXTRA_CXXFLAGS="\${ZOPEN_EXTRA_CXXFLAGS} -I\$PWD/include"

--- a/patches/TERMINFO.patch
+++ b/patches/TERMINFO.patch
@@ -1,0 +1,46 @@
+diff --git a/ncurses/tinfo/db_iterator.c b/ncurses/tinfo/db_iterator.c
+index f072668..2907f11 100644
+--- a/ncurses/tinfo/db_iterator.c
++++ b/ncurses/tinfo/db_iterator.c
+@@ -217,7 +217,13 @@ _nc_tic_dir(const char *path)
+ 	} else if (HaveTicDirectory == 0) {
+ 	    if (use_terminfo_vars()) {
+ 		const char *envp;
++#ifdef __MVS__
++		if ((envp = getenv("ASCII_TERMINFO")) != 0)
++		    return _nc_tic_dir(envp);
++		if ((envp = getenv("TERMINFO")) != 0)
++#else
+ 		if ((envp = getenv("TERMINFO")) != 0)
++#endif
+ 		    return _nc_tic_dir(envp);
+ 	    }
+ 	}
+@@ -318,7 +324,11 @@ _nc_first_db(DBDIRS * state, int *offset)
+ 
+ 	if (use_terminfo_vars()) {
+ #if NCURSES_USE_DATABASE
++#ifdef __MVS__
++	    values[dbdEnvOnce] = cache_getenv("ASCII_TERMINFO", dbdEnvOnce);
++#else
+ 	    values[dbdEnvOnce] = cache_getenv("TERMINFO", dbdEnvOnce);
++#endif
+ 	    values[dbdHome] = _nc_home_terminfo();
+ 	    (void) cache_getenv("HOME", dbdHome);
+ 	    values[dbdEnvList] = cache_getenv("TERMINFO_DIRS", dbdEnvList);
+diff --git a/ncurses/tinfo/write_entry.c b/ncurses/tinfo/write_entry.c
+index cab4757..7084670 100644
+--- a/ncurses/tinfo/write_entry.c
++++ b/ncurses/tinfo/write_entry.c
+@@ -220,7 +220,11 @@ _nc_set_writedir(const char *dir)
+ 	&& use_terminfo_vars()
+ #endif
+ 	)
++#ifdef __MVS__
++	dir = getenv("ASCII_TERMINFO");
++#else
+ 	dir = getenv("TERMINFO");
++#endif
+ 
+     if (dir != 0)
+ 	(void) _nc_tic_dir(dir);


### PR DESCRIPTION
/bin/vi does not like the TERMINFO database from ncurses, results in garbled characters. So we'll use ASCII_TERMINFO instead